### PR TITLE
Create host_-_subscription_base_data.erb

### DIFF
--- a/app/views/unattended/report_templates/host_-_subscription_base_data.erb
+++ b/app/views/unattended/report_templates/host_-_subscription_base_data.erb
@@ -1,0 +1,40 @@
+<%#
+name: Host - Subscription Base Data
+snippet: false
+template_inputs:
+- name: Hosts filter
+  required: false
+  input_type: user
+  description: Limit the report only on hosts found by this search query. Keep empty
+    for report on all available hosts.
+  advanced: false
+  value_type: search
+  resource_type: Host
+model: ReportTemplate
+require:
+- plugin: katello
+  version: 3.9.0
+-%>
+<%- report_headers 'Host Name', 'IP Address', 'Organization', 'Lifecycle Environment', 'Content View', 'Virtual', 'Guest of Host', 'OS', 'Arch', 'Sockets', 'Cores', 'Role', 'Usage', 'SLA', 'Release Version', 'Is Hypervisor', 'Products' -%>
+<%- load_hosts(search: input('Hosts filter'), includes: [:content_view_environments, :host_collections, :operatingsystem, :architecture, :organization, :reported_data, :interfaces]).each_record do |host| -%>
+<%-   report_row(
+          'Host Name': host.name,
+          'IP Address': host.ip,
+          'Organization': host.organization,
+          'Lifecycle Environment': host.single_lifecycle_environment ? host.single_lifecycle_environment.name : nil,
+          'Content View': host.single_content_view ? host.single_content_view.name : nil,
+          'Virtual': host.virtual,
+          'Guest of Host': host.hypervisor_host,
+          'OS': host.operatingsystem,
+          'Arch': host.architecture,
+          'Sockets': host.sockets,
+          'Cores': host.cores,
+          'Role': host_purpose_role(host),
+          'Usage': host_purpose_usage(host),
+          'SLA': host_sla(host),
+          'Release Version': host_purpose_release_version(host),
+          'Is Hypervisor': host_is_hypervisor(host),
+          'Products': host_products_names(host)
+      ) -%>
+<%- end -%>
+<%= report_render -%>


### PR DESCRIPTION
This commit provides a new report to delivering host data based on system purpose information for SCA enabled customers.

Requires katello commit
https://github.com/parmstro/katello/commit/d9c1fda5d0d3c7e094b3fd48d952ae962287699e


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
